### PR TITLE
Update routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 RedmineApp::Application.routes.draw do
-  match 'httpauth-login', :to => 'welcome#index'
-  match 'httpauth-selfregister', :to => 'registration#register'
+  get 'httpauth-login', :to => 'welcome#index'
+  get 'httpauth-selfregister', :to => 'registration#register'
 end


### PR DESCRIPTION
Redmine 3.x want:
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action".